### PR TITLE
Adds monoidal structures

### DIFF
--- a/LeanPoly.lean
+++ b/LeanPoly.lean
@@ -1,0 +1,1 @@
+import «LeanPoly».Poly

--- a/LeanPoly/Poly.lean
+++ b/LeanPoly/Poly.lean
@@ -342,6 +342,289 @@ instance Poly.subst.monoidal : MonoidalCategory Poly where
 --   counit  : carrier ⟶ y
 --   comult  : carrier ⟶ (carrier ◁ carrier)
 
+/-!
+## Co-Product
+-/
+
+def coproduct (p q : Poly.{u, u}) : Poly.{u, u} where
+  pos := p.pos ⊕ q.pos
+  dir := λ x ↦ 
+    match x with
+      | .inl ppos => p.dir ppos
+      | .inr qpos => q.dir qpos
+
+infixr:75 " + " => coproduct
+
+def coproduct.map (p q r z : Poly.{u, u}) (f : p ⟶ q) (g : r ⟶ z) : (p + r) ⟶ (q + z) := 
+    { onPos := λ pos ↦
+      match pos with
+        | .inl ppos => .inl (f.onPos ppos)
+        | .inr qpos => .inr (g.onPos qpos)
+    , onDir := λ pos ↦
+      match pos with
+        | .inl ppos => f.onDir ppos
+        | .inr rpos => g.onDir rpos
+    }
+
+def coproduct.whiskerLeft (p : Poly) {q q' : Poly} (f : q ⟶ q') : p + q ⟶ p + q' :=
+  (coproduct.map p p q q' ) (polyid p) f
+
+def coproduct.whiskerRight {p p' : Poly} (f : p ⟶ p') (q : Poly) : p + q ⟶ p' + q :=
+  (coproduct.map p p' q q) f (polyid q)
+  
+def coproduct.split.l {p : Poly.{u, u}} : p ⟶ p + p := 
+  { onPos := λ ppos ↦ .inl ppos
+  , onDir := λ _ppos ↦ id
+  }
+  
+def coproduct.split.r {p : Poly.{u, u}} : p ⟶ p + p := 
+  { onPos := λ ppos ↦ .inr ppos
+  , onDir := λ _ppos pdir ↦ pdir
+  }
+
+def coproduct.leftUnitor.hom (p : Poly) : (𝟬 + p) ⟶ p where
+  onPos := λ pos ↦
+  match pos with
+  | .inr ppos => ppos
+  onDir := λ pos ↦
+  match pos with
+  | .inr _ppos => id
+
+def coproduct.leftUnitor.inv (p : Poly) : p ⟶ (𝟬 + p) where
+  onPos := λ ppos ↦ .inr ppos
+  onDir := λ _ppos pdir ↦ pdir
+
+-- TODO:
+-- def coproduct.leftUnitor (p : Poly) : (𝟬 + p) ≅ p where
+--   hom := coproduct.leftUnitor.hom p
+--   inv := coproduct.leftUnitor.inv p
+--   hom_inv_id := _
+--   inv_hom_id := by {
+--     _
+--   }
+
+-- TODO:
+-- instance Poly.coproduct.monoidalStruct : MonoidalCategoryStruct Poly where
+--   tensorObj    := coproduct
+--   whiskerLeft  := coproduct.whiskerLeft
+--   whiskerRight := coproduct.whiskerRight
+--   tensorUnit   := 𝟬
+--   leftUnitor   := _
+--   rightUnitor  := _
+--   associator   := _
+  
+/-!
+## Cartesian product
+-/
+
+def product (p q : Poly.{u, u}) : Poly.{u, u} where
+  pos := p.pos × q.pos
+  dir := λ (ppos , qpos) =>  Sum (p.dir ppos) (q.dir qpos)
+
+infixr:85 " × " => product
+
+def product.map (p q r z : Poly.{u, u}) (f : p ⟶ q) (g : r ⟶ z) : (p × r) ⟶ (q × z) := 
+    { onPos := λ (ppos , rpos) => (f.onPos ppos , g.onPos rpos)
+    , onDir := λ (ppos , rpos) dir =>
+      match dir with
+        | .inl qdir => .inl (f.onDir ppos qdir)
+        | .inr zdir => .inr (g.onDir rpos zdir)
+    }
+    
+def product.whiskerLeft (p : Poly) {q q' : Poly} (f : q ⟶ q') : p × q ⟶ p × q' :=
+  (product.map p p q q' ) (polyid p) f
+
+def product.whiskerRight {p p' : Poly} (f : p ⟶ p') (q : Poly) : p × q ⟶ p' × q :=
+  (product.map p p' q q) f (polyid q)
+
+def product.fst {p q : Poly} : (p × q) ⟶ p := 
+  { onPos := λ (ppos , _qpos) => ppos
+  , onDir := λ (_ppos , _qpos) pdir => .inl pdir
+  }
+
+def product.snd {p q : Poly} : (p × q) ⟶ q := 
+  { onPos := λ (_ppos , qpos) => qpos
+  , onDir := λ (_ppos , _qpos) qdir => .inr qdir
+  }
+
+def product.swap {p q : Poly} : (p × q) ⟶ (q × p) := 
+  { onPos := λ (ppos , qpos) => (qpos , ppos)
+  , onDir := λ (_ppos , _qpos) dir =>
+        match dir with
+          | .inl qdir => .inr qdir
+          | .inr pdir => .inl pdir
+  }
+
+def product.dupe {p : Poly} : p ⟶ p × p := 
+  { onPos := λ ppos => (ppos , ppos)
+  , onDir := λ _pos dir =>
+        match dir with
+          | .inl pdir => pdir
+          | .inr pdir => pdir
+  }
+
+def product.fanout {p q r : Poly} (f : r ⟶ p) (g : r ⟶ q) : r ⟶ p × q :=
+  { onPos := λ rpos => (f.onPos rpos , g.onPos rpos)
+  , onDir := λ rpos dir =>
+        match dir with
+          | .inl pdir => f.onDir rpos pdir
+          | .inr qdir => g.onDir rpos qdir
+  }
+
+def product.leftUnitor.hom (p : Poly) : (𝟭 × p) ⟶ p where
+  onPos := λ (_Unit , ppos) ↦ ppos
+  onDir := λ (_Unit , _ppos) pdir ↦ .inr pdir
+
+def product.leftUnitor.inv (p : Poly) : p ⟶ (𝟭 × p) where
+  onPos := λ ppos ↦ (.unit , ppos)
+  onDir := λ _ppos dir ↦
+  match dir with
+  | .inr pfib => pfib
+  
+-- TODO:
+-- def product.leftUnitor (p : Poly) : (𝟭 × p) ≅ p where
+--   hom := product.leftUnitor.hom p
+--   inv := product.leftUnitor.inv p
+--   hom_inv_id := _
+--   inv_hom_id := by {
+--     _
+--   }
+
+/-!
+## Parallel product
+-/
+
+def tensor (p q : Poly.{u, u}) : Poly.{u, u} where
+  pos := p.pos × q.pos
+  dir := λ (ppos , qpos) =>  (p.dir ppos) × (q.dir qpos)
+  
+infixr:90 " ⊗ " => tensor
+
+def tensor.map (p q r z : Poly.{u, u}) (f : p ⟶ q) (g : r ⟶ z) : p ⊗ r ⟶ q ⊗ z := 
+    { onPos := λ (ppos , rpos) => (f.onPos ppos , g.onPos rpos)
+    , onDir := λ (ppos , rpos) (qdir , zdir) => (f.onDir ppos qdir , g.onDir rpos zdir) 
+    }
+    
+def tensor.whiskerLeft (p : Poly) {q q' : Poly} (f : q ⟶ q') : p ⊗ q ⟶ p ⊗ q' :=
+  (tensor.map p p q q' ) (polyid p) f
+
+def tensor.whiskerRight {p p' : Poly} (f : p ⟶ p') (q : Poly) : p ⊗ q ⟶ p' ⊗ q :=
+  (tensor.map p p' q q) f (polyid q)
+
+def tensor.first {p q r : Poly.{u, u}} (f : p ⟶ r) : p ⊗ q ⟶ r ⊗ q :=
+  (tensor.map p r q q) f (polyid q)
+
+def tensor.second {p q r : Poly.{u, u}} (g : q ⟶ r) : p ⊗ q ⟶ p ⊗ r :=
+  (tensor.map p p q r) (polyid p) g
+
+def tensor.swap {p q : Poly} : p ⊗ q ⟶ q ⊗ p :=
+  { onPos := λ (ppos , qpos) => (qpos , ppos)
+  , onDir := λ _ (qdir , pdir) => (pdir , qdir)
+  }
+
+def tensor.assoc.fwd {p q r : Poly} : p ⊗ (q ⊗ r) ⟶ (p ⊗ q) ⊗ r :=
+  { onPos := λ (ppos , qpos , rpos) => ((ppos , qpos) , rpos)
+  , onDir := λ _ ((pdir, qdir) , rdir) => (pdir , qdir , rdir)
+  }
+
+def tensor.assoc.bwd {p q r : Poly} : (p ⊗ q) ⊗ r ⟶ p ⊗ (q ⊗ r) :=
+  { onPos := λ ((ppos , qpos) , rpos) => (ppos , qpos , rpos)
+  , onDir := λ _ (pdir , qdir , rdir) => ((pdir , qdir) , rdir)
+  }
+
+def tensor.split.l {p : Poly} : p ⟶ p ⊗ p :=
+  { onPos := λ ppos => (ppos , ppos)
+  , onDir := λ _ (f , _) => f
+  }
+
+def tensor.split.r {p : Poly} : p ⟶ p ⊗ p :=
+  { onPos := λ ppos => (ppos , ppos)
+  , onDir := λ _ (_ , g) => g
+  }
+
+def tensor.unit.l.fwd {P : Poly} : y ⊗ P ⟶ P :=
+  { onPos := λ (_ , ppos) => ppos
+  , onDir := λ (Unit, _) pdir => (Unit , pdir)
+  }
+
+def tensor.unit.l.bwd {P : Poly} : P ⟶ y ⊗ P :=
+  { onPos := λ ppos => (Unit.unit , ppos)
+  , onDir := λ _ (_ , pdir) => pdir
+  }
+
+def tensor.unit.r.fwd {P : Poly} : P ⊗ y ⟶ P :=
+  { onPos := λ (ppos , _) => ppos
+  , onDir := λ (_ , Unit) pdir => (pdir , Unit)
+  }
+
+def tensor.unit.r.bwd {P : Poly} : P ⟶ P ⊗ y :=
+  { onPos := λ ppos => (ppos , Unit.unit)
+  , onDir := λ _ (pdir , _) => pdir
+  }
+
+/-!
+## Or product
+-/
+  
+def or (p q : Poly.{u, u}) : Poly.{u, u} := p + (p × q) + q
+
+infixr:75 " ∨ " => or
+
+def or.map (p q r z : Poly.{u, u}) (f : p ⟶ q) (g : r ⟶ z) : (p ∨ r) ⟶ (q ∨ z) := 
+    { onPos := λ pos =>
+      match pos with
+      | .inl ppos => .inl (f.onPos ppos)
+      | .inr (.inl (ppos , rpos)) => .inr (.inl (f.onPos ppos , g.onPos rpos))
+      | .inr (.inr rpos) => .inr (.inr (g.onPos rpos))
+    , onDir := λ pos fib =>
+      match pos with
+      | .inl ppos => f.onDir ppos fib
+      | .inr (.inl (ppos , rpos)) =>
+        match fib with
+        | .inl qfib => .inl (f.onDir ppos qfib)
+        | .inr zfib => .inr (g.onDir rpos zfib)
+      | .inr (.inr rpos) => g.onDir rpos fib
+    }
+
+def or.whiskerLeft (p : Poly) {q q' : Poly} (f : q ⟶ q') : p ∨ q ⟶ p ∨ q' :=
+  (or.map p p q q' ) (polyid p) f
+
+def or.whiskerRight {p p' : Poly} (f : p ⟶ p') (q : Poly) : p ∨ q ⟶ p' ∨ q :=
+  (or.map p p' q q) f (polyid q)
+  
+
+-- | _∨_ This Inclusion
+def This {p q : Poly} : p ⟶ p ∨ q :=
+  { onPos := .inl
+  , onDir := λ _ => id
+  }
+
+-- | _∨_ That Inclusion
+def That {p q : Poly} : q ⟶ p ∨ q :=
+  { onPos := .inr ∘ .inr
+  , onDir := λ _ => id
+  }
+
+-- | _∨_ These Inclusion
+def These {p q : Poly} : (p × q) ⟶ p ∨ q :=
+  { onPos := .inr ∘ .inl
+  , onDir := λ _ => id
+  }
+
+-- | _∨_ Eliminator
+def these {p q r : Poly} (f : p ⟶ r) (g : q ⟶ r) (h : (p × q) ⟶ r) : ((p ∨ q) ⟶ r) :=
+  { onPos := λ pos => 
+    match pos with
+    | .inl ppos => f.onPos ppos
+    | .inr (.inl (ppos , qpos)) => h.onPos (ppos , qpos)
+    | .inr (.inr qpos) => g.onPos qpos
+  , onDir := λ pos fib =>
+    match pos with
+    | .inl ppos => f.onDir ppos fib
+    | .inr (.inl (ppos , qpos)) => h.onDir (ppos , qpos) fib
+    | .inr (.inr qpos) => g.onDir qpos fib
+  }
+
 
 end Poly
 


### PR DESCRIPTION
Adds Product, Coproduct, Tensor, and Or along with a variety of common combinators for each. 

I've started writing the `MonoidalCategoryStruct` records for each but the proofs for these were not able able to derived automatically as they were with `subst.` I'll keep working on this branch as I learn how to write the needed proofs.